### PR TITLE
Using composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
             "email": "nouraellm@gmail.com"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
     "require": {
         "twig/twig": "^2.0"
     }

--- a/public/index.php
+++ b/public/index.php
@@ -7,12 +7,6 @@ define('PATH', __DIR__ . DS);
 require __DIR__.'/../vendor/autoload.php';
 
 // Required files
-require_once PATH.'../app/Errors.php';
-require_once PATH.'../app/Core.php';
-require_once PATH.'../app/Controller.php';
-require_once PATH.'../app/Model.php';
-require_once PATH.'../app/View.php';
-require_once PATH.'../app/Database.php';
 require_once PATH.'../conf/Config.php';
 require_once PATH.'../conf/Functions.php';
 


### PR DESCRIPTION
This is a simple change, it's preferable to use composer's autoload. instead of the "required" for those classes under the `App\` namespace.